### PR TITLE
Fix perl version for win-32/win-64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - 0003-Use-cmake-E-tar-to-extract-test-data.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   features:
     - vc9   # [win and py27]
     - vc10  # [win and py34]
@@ -39,7 +39,7 @@ requirements:
     - vc 14  # [win and py35]
     - vc 14  # [win and py36]
     # perl is needed to run the package tests
-    - perl 5.26.0  # avoid making a matrix of perl builds
+    - perl 5.26.0.*  # avoid making a matrix of perl builds
   run:
     - zlib 1.2.11
     - bzip2 1.0.*


### PR DESCRIPTION
Perl is tagged as `5.26.0.1` on `win-32`/`win-64` but `5.26.0` on `linux`/`osx`. Should be able to get compatible version with a single wildcard.

```bash
$ for platform in win-32 win-64 linux-64 osx-64; do
      conda search --spec --platform=$platform "perl=5.26.0.*"
  done
Fetching package metadata .............
perl                         5.26.0.1             h626d98a_0  defaults        
Fetching package metadata .............
perl                         5.26.0.1             hbb76ec5_0  defaults        
Fetching package metadata .............
perl                         5.26.0               hae598fd_0  defaults        
Fetching package metadata .............
perl                         5.26.0               h5b8ca18_0  defaults
```