### PR TITLE
Fix missing Windows builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2
 
 jobs:
-  build__CONDA_PERL_5.26.0:
+  build__CONDA_PERL_5.20.3.1:
     working_directory: ~/test
     machine: true
     environment:
-      - CONDA_PERL: "5.26.0"
+      - CONDA_PERL: "5.20.3.1"
     steps:
       - checkout
       - run:
@@ -27,4 +27,4 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build__CONDA_PERL_5.26.0
+      - build__CONDA_PERL_5.20.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ osx_image: xcode6.4
 env:
   matrix:
     
-    - CONDA_PERL=5.26.0
+    - CONDA_PERL=5.20.3.1
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "KvYJnKTz+PnAAkckV147zmSNtG0paaC+AfY3oBZQdsumeqFaLsb4T4NKBkDa8pH9AHLHEUtPKGAV8uT4jSRQX1Q4LX8u+pAYQ42yQqVWwwxsJtTIgemn7bzJDST9M2zNbBxGxV9MW75ww+T32EzjXHAgHk6Uc/DSMDrIkCs0Z0pmrgfd8IcQYAg0fFnO/Q3npNXGb/NlJAR3m5vjAMjdhg7Mum5RAOtdxETJsSYBbbpiezKwjfmBKu0RCniptdZpSkbUkVZlsS7DnpBxuUOHj7BgtQxyfQ3Q2sHjJEIr+1+QDx4AuXK7yshgH2+G1NMh/G2+UGUEyqOHVK2opOEf8PSeXeSUF4wrpBMqtoCzeZcdLiwur+j/QCxv4zFJIimUUT3G0KxGcgVujFTjR8ShhBHupLTqOE4GQ29AvVOh1cNlW7NLNSM0a8ChNCSW8hC43zSduReGVYM2ejZX4H6/FNbsyugkw/JSREIndB8otTLtqzC+m3PiA9zk6YxON0q3ftm2Eca/agkNFMUEj6k7cghlY2ZghDBDv8qw1ZsloPOyst+JHAeEZqWyiiJrIQGx7Aib3jSaMXckCRPYZf9y0L98PE2vK0KAv+GxTyblqn3mW5TvIHOmbPKRatgjvYZUVnPEZguKjHOw/qx0YZnS6xn42AgQD2zy0f4Jzcrl4Qo="

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,12 +10,34 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
+      CONDA_PERL: 5.20.3.1
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
+      CONDA_PERL: 5.20.3.1
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
+    - TARGET_ARCH: x86
+      CONDA_PERL: 5.20.3.1
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_PERL: 5.20.3.1
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_PERL: 5.20.3.1
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
+
+    - TARGET_ARCH: x64
+      CONDA_PERL: 5.20.3.1
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,16 +21,6 @@ environment:
 
     - TARGET_ARCH: x86
       CONDA_PERL: 5.20.3.1
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
-
-    - TARGET_ARCH: x64
-      CONDA_PERL: 5.20.3.1
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x86
-      CONDA_PERL: 5.20.3.1
       CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda36
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,8 @@ source:
     - 0003-Use-cmake-E-tar-to-extract-test-data.patch  # [win]
 
 build:
+  # Skip py35 since py36 is built and uses same vc14
+  skip: True  # [win and py35]
   number: 2
   features:
     - vc9   # [win and py27]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - 0003-Use-cmake-E-tar-to-extract-test-data.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   features:
     - vc9   # [win and py27]
     - vc10  # [win and py34]
@@ -39,7 +39,7 @@ requirements:
     - vc 14  # [win and py35]
     - vc 14  # [win and py36]
     # perl is needed to run the package tests
-    - perl 5.26.0.*  # avoid making a matrix of perl builds
+    - perl 5.20.3.1  # avoid making a matrix of perl builds
   run:
     - zlib 1.2.11
     - bzip2 1.0.*


### PR DESCRIPTION
Bad Perl pinning prevented `vc14` (`py35` or `py36`) builds.