### PR TITLE
Add openssl and rerender

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -10,9 +10,13 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil-comp7
+openssl:
+- 1.1.1a
 pin_run_as_build:
   bzip2:
     max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 zlib:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -14,9 +14,13 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+openssl:
+- 1.1.1a
 pin_run_as_build:
   bzip2:
     max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 zlib:

--- a/.ci_support/win_c_compilervs2008.yaml
+++ b/.ci_support/win_c_compilervs2008.yaml
@@ -6,9 +6,13 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+openssl:
+- 1.1.1a
 pin_run_as_build:
   bzip2:
     max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 zlib:

--- a/.ci_support/win_c_compilervs2015.yaml
+++ b/.ci_support/win_c_compilervs2015.yaml
@@ -6,9 +6,13 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+openssl:
+- 1.1.1a
 pin_run_as_build:
   bzip2:
     max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 zlib:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   # Skip py35 since py36 is built and uses same vc14
-  number: 1003
+  number: 1004
 
 requirements:
   build:
@@ -23,10 +23,12 @@ requirements:
   host:
     - zlib
     - bzip2
+    - openssl
     # perl is needed to run the package tests
   run:
     - zlib
     - bzip2
+    - openssl
 
 test:
   commands:


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Looks like there is a missing pin in this recipe -- libzip will apparently build some components against `openssl`, and I think this may be related to an issue we're seeing in the QGIS recipe (conda-forge/qgis-feedstock#55). Regardless it seems a good idea to actually list the dependency

I noticed this because libzip showed up as one of the things QGIS links to that could not find `libcrypto`. Here's what shows up in the build logs related to `openssl`

During configure:
```
-- Detecting C compile features
-- Detecting C compile features - done
-- Looking for include file CommonCrypto/CommonCrypto.h
-- Looking for include file CommonCrypto/CommonCrypto.h - not found
-- Could NOT find NETTLE (missing: NETTLE_LIBRARY NETTLE_INCLUDE_DIR) 
-- Could NOT find GnuTLS (missing: GNUTLS_LIBRARY GNUTLS_INCLUDE_DIR) 
-- Found OpenSSL: $BUILD_PREFIX/lib/libcrypto.so (found version "1.1.1b")  
```

Compiling:
```
[ 44%] Building C object lib/CMakeFiles/zip.dir/zip_crypto_openssl.c.o
```