### PR TITLE
Fixed pkgconfig files (mostly on Windows)

### DIFF
--- a/recipe/fix-zstd-pkgconfig.patch
+++ b/recipe/fix-zstd-pkgconfig.patch
@@ -1,0 +1,23 @@
+From c719428916b4d19e838f873b1a177b126a080d61 Mon Sep 17 00:00:00 2001
+From: Thomas Klausner <wiz@gatalith.at>
+Date: Thu, 24 Aug 2023 14:07:50 +0200
+Subject: [PATCH] Check for zstd_TARGET before using it in a regex.
+
+Closes #404.
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b2e77241..b7bb7e3f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -349,7 +349,7 @@ endforeach()
+ STRING(CONCAT zlib_link_name "-l" ${ZLIB_LINK_LIBRARY_NAME})
+ string(REGEX REPLACE "-lBZip2::BZip2" "-lbz2" LIBS ${LIBS})
+ string(REGEX REPLACE "-lLibLZMA::LibLZMA" "-llzma" LIBS ${LIBS})
+-if(ENABLE_ZSTD)
++if(zstd_TARGET)
+   string(REGEX REPLACE "-l${zstd_TARGET}" "-lzstd" LIBS ${LIBS})
+ endif()
+ string(REGEX REPLACE "-lOpenSSL::Crypto" "-lssl -lcrypto" LIBS ${LIBS})

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
   sha256: {{ sha256 }}
   patches:
     - fix-bz2-pkgconfig-win.patch  # [win]
+    - fix-zstd-pkgconfig.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This PR imports the fix for issues https://github.com/nih-at/libzip/issues/399 and https://github.com/nih-at/libzip/issues/404 . It is essential for this library working on Windows. This patch should be removed when new upstream release is done, as it will be included.

The current bad pkgconfig file on Windows looks like this:

```
prefix=D:/Programy/conda-envs/ign8/Library
exec_prefix=${prefix}
bindir=${prefix}/bin
libdir=${prefix}/lib
includedir=${prefix}/include

zipcmp=${bindir}/zipcmp

Name: libzip
Description: library for handling zip archives
Version: 1.10.1
Libs:  -L${libdir} -lzip
Libs.private:  -lzstdadvapi32 -lzstdbzip2 -lzstdbcrypt -lzstdZLIB::ZLIB
Cflags: -I${includedir}
```

Notice `Libs.private` contains garbage, making it impossible to build anything against libzip.