### PR TITLE
Fix LZMA on Windows

### DIFF
--- a/recipe/fix-lzma-pkgconfig-win.patch
+++ b/recipe/fix-lzma-pkgconfig-win.patch
@@ -1,0 +1,22 @@
+From e8eff4391791086d86d6f8cb5cdb90c7e6f239f8 Sun Sep 2 22:54:00 2023
+From: Martin Pecka <peci1@seznam.cz>
+Date: Sun, 3 Sep 2023 05:17:52 +0200
+Subject: [PATCH] Fix lzma name to match the one of conda-forge on Windows
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b2e77241..b6e1cb6a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -348,7 +348,7 @@ foreach(LIB ${LIBS_PRIVATE})
+ endforeach()
+ STRING(CONCAT zlib_link_name "-l" ${ZLIB_LINK_LIBRARY_NAME})
+ string(REGEX REPLACE "-lBZip2::BZip2" "-lbzip2" LIBS ${LIBS})
+-string(REGEX REPLACE "-lLibLZMA::LibLZMA" "-llzma" LIBS ${LIBS})
++string(REGEX REPLACE "-lLibLZMA::LibLZMA" "-lliblzma" LIBS ${LIBS})
+  if(zstd_TARGET)
+   string(REGEX REPLACE "-l${zstd_TARGET}" "-lzstd" LIBS ${LIBS})
+  endif()

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,10 @@ source:
   patches:
     - fix-bz2-pkgconfig-win.patch  # [win]
     - fix-zstd-pkgconfig.patch
+    - fix-lzma-pkgconfig-win.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 
@@ -29,6 +30,8 @@ requirements:
     - zlib
     - bzip2
     - openssl
+    - xz  # [win]
+    - zstd  # [win]
     # perl is needed to run the package tests
 
 test:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

After #37, the Windows pkg-config file reads:

```
Libs.private:  -ladvapi32 -lbzip2 -llzma -lzstd -lbcrypt -lz
```

But the host dependencies are only:

```
host:
    - zlib
    - bzip2
    - openssl
```

bzip2, z, advapi32 and bcrypt are covered by the dependencies, while zstd and lzma are not.

lzma can be found in conda package xz, zstd in package zstd. So I added these as dependencies.

However, even without being in dependencies, they probably got pulled in somehow transitively - that's why their flags are in .pc file. But I think having the dependencies explicit is good.

Moreover, lzma is named liblzma on windows:

https://github.com/conda-forge/xz-feedstock/blob/0d1084422b26392f22e9205318808a45230ff836/recipe/meta.yaml#L44

so I renamed the flag using the same approach that was recently used for bzip.

